### PR TITLE
Adding widget returns to plot functions

### DIFF
--- a/rfsoc_qpsk/qpsk_overlay.py
+++ b/rfsoc_qpsk/qpsk_overlay.py
@@ -239,7 +239,7 @@ class QpskOverlay(Overlay):
         for i, title in enumerate(titles):
             tab_widget.set_title(i, title)
         
-        QpskOverlay._tab_load_resizer_callback(tab_widget)
+        #QpskOverlay._tab_load_resizer_callback(tab_widget)
 
         return tab_widget
 

--- a/rfsoc_qpsk/qpsk_overlay.py
+++ b/rfsoc_qpsk/qpsk_overlay.py
@@ -239,15 +239,14 @@ class QpskOverlay(Overlay):
         for i, title in enumerate(titles):
             tab_widget.set_title(i, title)
         
-        #QpskOverlay._tab_load_resizer_callback(tab_widget)
+        QpskOverlay._tab_load_resizer_callback(tab_widget)
 
         return tab_widget
 
     @staticmethod
     def _tab_load_resizer_callback(tabs):
         """Helper function to handle relative widths for plots in hidden tabs"""
-        display(tabs)
-
+        
         out = ipw.Output()
         display(out)
 

--- a/rfsoc_qpsk/qpsk_overlay.py
+++ b/rfsoc_qpsk/qpsk_overlay.py
@@ -216,7 +216,7 @@ class QpskOverlay(Overlay):
                                   layout=ipw.Layout(width='550px', margin='auto')))
                 
         self.timers.register_timers(group_name, list(map(lambda tab: tab['control'], plots)))
-        QpskOverlay.tab_plots(plots)
+        return QpskOverlay.tab_plots(plots)
         
     @staticmethod
     def tab_plots(tabs):
@@ -240,6 +240,8 @@ class QpskOverlay(Overlay):
             tab_widget.set_title(i, title)
         
         QpskOverlay._tab_load_resizer_callback(tab_widget)
+
+        return tab_widget
 
     @staticmethod
     def _tab_load_resizer_callback(tabs):


### PR DESCRIPTION
Hello! 
Would be really useful to have widgets to play with in the notebooks without editing the .py files. I added some return functions and removed the _tab_load_resizer_callback (which is probably a bad idea) to make it work for my purposes... Perhaps there's a more elegant way. Meant this as a draft pull