### PR TITLE
Update ZCU111 qpsk_overlay function to match RFSoC2x2

### DIFF
--- a/boards/ZCU111/rfsoc_qpsk/drivers/qpsk_overlay.py
+++ b/boards/ZCU111/rfsoc_qpsk/drivers/qpsk_overlay.py
@@ -102,7 +102,7 @@ class QpskOverlay(Overlay):
         
         # Start up LMX clock
         if init_rf_clks:
-            xrfclk.set_all_ref_clks(409.6)
+            xrfclk.set_ref_clks()
 
         # Set sane DAC defaults
         self.dac_tile.DynamicPLLConfig(1, 409.6, 1228.8)


### PR DESCRIPTION
ZCU111 and RFSoC2x2 drivers are being unified, this change will resolve an error now on the ZCU111.